### PR TITLE
DSL for all_db_columns in index

### DIFF
--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -159,7 +159,7 @@ module CmAdmin
     end
 
     def all_columns(options={})
-      field_names = self.instance_variable_get(:@ar_masdaodel)&.columns&.map{|x| x.name.to_sym}
+      field_names = self.instance_variable_get(:@ar_model)&.columns&.map{|x| x.name.to_sym}
       if options.include?(:exclude) && field_names
         excluded_fields = (Array.new << options[:exclude]).flatten.map(&:to_sym)
         field_names -= excluded_fields

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -158,8 +158,12 @@ module CmAdmin
       @available_fields[:index] << field_name
     end
 
-    def all_columns
+    def all_columns(options={})
       field_names = self.instance_variable_get(:@ar_masdaodel)&.columns&.map{|x| x.name.to_sym}
+      if options.include?(:exclude) && field_names
+        excluded_fields = (Array.new << options[:exclude]).flatten.map(&:to_sym)
+        field_names -= excluded_fields
+      end
       current_action_name = @current_action.name.to_sym
       @available_fields[current_action_name] |= field_names if field_names
     end

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -158,7 +158,7 @@ module CmAdmin
       @available_fields[:index] << field_name unless @available_fields[:index].include?(field_name)
     end
 
-    def all_columns(options={})
+    def all_db_columns(options={})
       field_names = self.instance_variable_get(:@ar_model)&.columns&.map{|x| x.name.to_sym}
       if options.include?(:exclude) && field_names
         excluded_fields = (Array.new << options[:exclude]).flatten.map(&:to_sym)

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -155,7 +155,7 @@ module CmAdmin
 
     def column(field_name)
       puts "For printing field #{field_name}"
-      @available_fields[:index] << field_name
+      @available_fields[:index] << field_name unless @available_fields[:index].include?(field_name)
     end
 
     def all_columns(options={})
@@ -167,6 +167,7 @@ module CmAdmin
       current_action_name = @current_action.name.to_sym
       @available_fields[current_action_name] |= field_names if field_names
     end
+
     def self.find_by(search_hash)
       CmAdmin.cm_admin_models.find { |x| x.name == search_hash[:name] }
     end

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -158,6 +158,11 @@ module CmAdmin
       @available_fields[:index] << field_name
     end
 
+    def all_columns
+      field_names = self.instance_variable_get(:@ar_masdaodel)&.columns&.map{|x| x.name.to_sym}
+      current_action_name = @current_action.name.to_sym
+      @available_fields[current_action_name] |= field_names if field_names
+    end
     def self.find_by(search_hash)
       CmAdmin.cm_admin_models.find { |x| x.name == search_hash[:name] }
     end


### PR DESCRIPTION
Sample DSL
```
cm_admin do
    actions only: [:index]
    cm_index do
        page_title "User lists"
        page_description "To list basic information about user"
        all_db_columns exclude: [:created_at, :updated_at]
        column :first_name
        column :last_name
    end
end
```
Even if the `column` is defined with the `all_db_columns` it is handled to show only the unique value in the table.