### PR TITLE
Configuration for different filter scopes

### DIFF
--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -118,7 +118,7 @@ module CmAdmin
       records
     end
 
-    def cm_search(scope_value, records)
+    def cm_search_filter(scope_value, records)
       return nil if scope_value.blank?
       table_name = records.table_name
 

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -143,6 +143,17 @@ module CmAdmin
       records
     end
 
+    def cm_date_and_range_filter(scope_value, records)
+      return nil if scope_value.nil?
+      scope_value.each do |key, value|
+        if value.present?
+          from, to = value.split(' - ')
+          records = records.where(key => from..to)
+        end
+      end
+      records
+    end
+
     def new(params)
       @ar_object = @ar_model.new
     end

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -104,8 +104,15 @@ module CmAdmin
     def filtered_data(filter_params)
       records = self.name.constantize.where(nil)
       if filter_params
-        filter_params.each do |scope, scope_value|
-          records = self.send("cm_#{scope}", scope_value, records)
+        filter_params.each do |scope_type, scope_value|
+          scope_name = if scope_type.eql?('date') || scope_type.eql?('range')
+            'date_and_range'
+          elsif scope_type.eql?('single_select') || scope_type.eql?('multi_select')
+            'dropdown'
+          else
+            scope_type
+          end
+          records = self.send("cm_#{scope_name}_filter", scope_value, records) if scope_value.present?
         end
       end
       records

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -154,6 +154,14 @@ module CmAdmin
       records
     end
 
+    def cm_dropdown_filter(scope_value, records)
+      return nil if scope_value.nil?
+      scope_value.each do |key, value|
+        records = records.where(key => value) if value.present?
+      end
+      records
+    end
+
     def new(params)
       @ar_object = @ar_model.new
     end

--- a/lib/cm_admin/models/filter.rb
+++ b/lib/cm_admin/models/filter.rb
@@ -3,7 +3,7 @@ module CmAdmin
     class Filter
       attr_accessor :db_column_name, :filter_type, :placeholder, :collection, :multiselect, :checked
 
-      VALID_FILTER_TYPES = Set[:checkbox, :date, :dropdown, :range, :search].freeze
+      VALID_FILTER_TYPES = Set[:date, :multi_select, :range, :search, :single_select].freeze
 
       def initialize(db_column_name:, filter_type:, options: {})
         raise TypeError, "Can't have array of multiple columns for #{filter_type} filter" if db_column_name.is_a?(Array) && db_column_name.size > 1 && !filter_type.to_sym.eql?(:search)

--- a/lib/cm_admin/models/filter.rb
+++ b/lib/cm_admin/models/filter.rb
@@ -1,7 +1,7 @@
 module CmAdmin
   module Models
     class Filter
-      attr_accessor :db_column_name, :filter_type, :placeholder, :collection, :multiselect, :checked
+      attr_accessor :db_column_name, :filter_type, :placeholder, :collection
 
       VALID_FILTER_TYPES = Set[:date, :multi_select, :range, :search, :single_select].freeze
 


### PR DESCRIPTION
1. Updating the VALID_FILTER_TYPES constant,
    - Checkbox filters are not required.
    - Dropdown filters are split into `single_select` and `multi_select`.
2. Configuring the filter scope for all the different filter types.
3. Dynamic permit of filter_params based on the added filters in the model.