### PR TITLE
Show field type

### DIFF
--- a/app/views/cm_admin/main/show.html.slim
+++ b/app/views/cm_admin/main/show.html.slim
@@ -6,8 +6,4 @@
         | Section heading
       .paper
         - @model.available_fields[:show].each do |field|
-          .info-split
-            .info-split__lhs
-              p = field.label.present? ? field.label.to_s : field.field_name.to_s.titleize
-            .info-split__rhs
-              p = @ar_object.send(field.field_name)
+          = show_field(@ar_object, field)

--- a/lib/cm_admin/models/field.rb
+++ b/lib/cm_admin/models/field.rb
@@ -1,7 +1,7 @@
 module CmAdmin
   module Models
     class Field
-      attr_accessor :field_name, :label, :header
+      attr_accessor :field_name, :label, :header, :field_type, :format, :precision
 
       def initialize(field_name, attributes = {})
         @field_name = field_name

--- a/lib/cm_admin/view_helpers.rb
+++ b/lib/cm_admin/view_helpers.rb
@@ -6,6 +6,7 @@ module CmAdmin
     include NavigationHelper
     include FormHelper
     include ColumnFieldHelper
+    include ShowFieldHelper
     include ActionView::Helpers::FormTagHelper
     include ActionView::Helpers::TagHelper
 

--- a/lib/cm_admin/view_helpers/show_field_helper.rb
+++ b/lib/cm_admin/view_helpers/show_field_helper.rb
@@ -1,11 +1,7 @@
 module CmAdmin
   module ViewHelpers
     module ShowFieldHelper
-           # .info-split__lhs
-              
-            # .info-split__rhs
-            #   p = @ar_object.send(field.field_name)
- 
+
       def show_field(ar_object, field)
         content_tag(:div, class: "info-split") do
           concat show_field_label(ar_object, field)

--- a/lib/cm_admin/view_helpers/show_field_helper.rb
+++ b/lib/cm_admin/view_helpers/show_field_helper.rb
@@ -1,0 +1,62 @@
+module CmAdmin
+  module ViewHelpers
+    module ShowFieldHelper
+           # .info-split__lhs
+              
+            # .info-split__rhs
+            #   p = @ar_object.send(field.field_name)
+ 
+      def show_field(ar_object, field)
+        content_tag(:div, class: "info-split") do
+          concat show_field_label(ar_object, field)
+          concat show_field_value(ar_object, field)
+        end
+      end
+
+      def show_field_label(ar_object, field)
+        content_tag(:div, class: "info-split__lhs") do
+          p = field.label.present? ? field.label.to_s : field.field_name.to_s.titleize
+        end
+      end
+      
+      def show_field_value(ar_object, field)
+        content_tag(:div, class: "info-split__lhs") do
+          case field.field_type
+          when :integer
+            ar_object.send(field.field_name).to_s
+          when :decimal
+            ar_object.send(field.field_name).to_f.to_s
+          when :string
+            ar_object.send(field.field_name)
+          when :datetime
+            ar_object.send(field.field_name).strftime(field.format || "%d/%m/%Y").to_s
+          when :text
+            ar_object.send(field.field_name)
+          when :link
+            content_tag :a, href: ar_object.send(field.field_name) do
+              ar_object.send(field.field_name).to_s
+            end 
+          when :attachment
+            concat show_attachment_value(ar_object, field)
+          end
+        end
+      end
+
+      def show_attachment_value(ar_object, field)
+        if ar_object.send(field.field_name).attached?
+          if ar_object.send(field.field_name).class.name.include?('One')
+            content_tag :a, href: rails_blob_path(ar_object.send(field.field_name), disposition: "attachment") do
+              ar_object.send(field.field_name).filename.to_s 
+            end
+          elsif ar_object.send(field.field_name).class.name.include?('Many')
+            ar_object.send(field.field_name).map do |asset|
+              content_tag :a, href: rails_blob_path(asset, disposition: "attachment") do
+                asset.filename.to_s 
+              end
+            end.join("\n").html_safe
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support for field type. Following are added.

1.  Integer
2. String
3. Datetime
4. Link
5. Attachment(Single and Multiple)
6. Decimal
7. Text

Missing type:
- Money
- Enum

Few more supporting options to be added yet.
- For decimal - precision
- For link, Custom value
- For attachment - preview 