### PR TITLE
Form generation for STI

### DIFF
--- a/cm_admin.gemspec
+++ b/cm_admin.gemspec
@@ -3,8 +3,8 @@ require_relative 'lib/cm_admin/version'
 Gem::Specification.new do |spec|
   spec.name          = "cm-admin"
   spec.version       = CmAdmin::VERSION
-  spec.authors       = ["sajinmp", "anbublacky", "manikandan0603"]
-  spec.email         = ["sajinprasadkm@gmail.com", "anbublacky@gmail.com"]
+  spec.authors       = ["sajinmp", "anbublacky", "AdityaTiwari2102"]
+  spec.email         = ["sajinprasadkm@gmail.com", "anbublacky@gmail.com", "taditya.tiwari007@gmail.com"]
 
   spec.summary       = %q{This is an admin panel gem}
   spec.description   = %q{This is an admin panel gem}

--- a/lib/cm_admin/version.rb
+++ b/lib/cm_admin/version.rb
@@ -1,3 +1,3 @@
 module CmAdmin
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/lib/cm_admin/view_helpers/form_helper.rb
+++ b/lib/cm_admin/view_helpers/form_helper.rb
@@ -22,7 +22,7 @@ module CmAdmin
 
       def form_with_all_fields(resource, method)
         columns = resource.class.columns.dup
-        table_name = resource.class.table_name
+        table_name = resource.model_name.collection
         columns.reject! { |i| REJECTABLE.include?(i.name) }
         url = CmAdmin::Engine.mount_path + "/#{table_name}/#{resource.id}"
         set_form_for_fields(resource, columns, url, method)
@@ -30,7 +30,7 @@ module CmAdmin
 
       def form_with_mentioned_fields(resource, available_fields, method)
         # columns = resource.class.columns.select { |i| available_fields.map(&:field_name).include?(i.name.to_sym) }
-        table_name = resource.class.table_name
+        table_name = resource.model_name.collection
         # columns.reject! { |i| REJECTABLE.include?(i.name) }
         url = CmAdmin::Engine.mount_path + "/#{table_name}/#{resource.id}"
         set_form_for_fields(resource, available_fields, url, method)


### PR DESCRIPTION
For inherited models, `class.table_name` would return the parent table. Which will not work for STI models. To handle this we can use `model_name.collection`.

Example,
```ruby
class Admin < User
  # Model specific code
end

class User < ApplicationRecord
  # Model specific code
end

Admin.new.class.table_name
  # => users
Admin.new.model_name.collection
  # => admins
```