### PR TITLE
Sortable columns

### DIFF
--- a/lib/cm_admin/models/column.rb
+++ b/lib/cm_admin/models/column.rb
@@ -31,12 +31,12 @@ module CmAdmin
       end
 
       def set_sort_columns
-        if sort_direction.present?
-          raise ArgumentError, "Kindly select a valid sort direction like #{VALID_SORT_DIRECTION.join(' or ')} instead of #{sort_direction} for column #{field_name}" unless VALID_SORT_DIRECTION.include?(sort_direction.to_sym.downcase)
-          sortable = true
-          sort_direction = sort_direction.to_s
+        if self.sort_direction.present?
+          raise ArgumentError, "Kindly select a valid sort direction like #{VALID_SORT_DIRECTION.join(' or ')} instead of #{self.sort_direction} for column #{self.field_name}" unless VALID_SORT_DIRECTION.include?(self.sort_direction.to_sym.downcase)
+          self.sortable = true
+          self.sort_direction = self.sort_direction.to_s
         end
-        sort_direction = 'asc' if sortable && !sort_direction
+        self.sort_direction = 'asc' if self.sortable && !self.sort_direction
       end
 
       #formatting value for different data types

--- a/lib/cm_admin/models/column.rb
+++ b/lib/cm_admin/models/column.rb
@@ -4,6 +4,8 @@ module CmAdmin
       attr_accessor :field_name, :field_type, :header, :format, :prefix, :suffix, :exportable, :round,
       :cm_css_class, :link, :url, :custom_method, :helper_method, :managable, :lockable, :sortable, :sort_direction
 
+      VALID_SORT_DIRECTION = Set[:asc, :desc].freeze
+
       def initialize(field_name, attributes = {})
         @field_name = field_name
         set_default_values

--- a/lib/cm_admin/models/column.rb
+++ b/lib/cm_admin/models/column.rb
@@ -15,6 +15,7 @@ module CmAdmin
 
         #formatting header (either field_name or value present in header attribute)
         self.send("header=", format_header)
+        set_sort_columns
       end
 
       #returns a string value as a header (either field_name or value present in header attribute)
@@ -26,6 +27,16 @@ module CmAdmin
         self.exportable = true
         self.managable = true
         self.lockable = false
+        self.sortable = false
+      end
+
+      def set_sort_columns
+        if sort_direction.present?
+          raise ArgumentError, "Kindly select a valid sort direction like #{VALID_SORT_DIRECTION.join(' or ')} instead of #{sort_direction} for column #{field_name}" unless VALID_SORT_DIRECTION.include?(sort_direction.to_sym.downcase)
+          sortable = true
+          sort_direction = sort_direction.to_s
+        end
+        sort_direction = 'asc' if sortable && !sort_direction
       end
 
       #formatting value for different data types

--- a/lib/cm_admin/models/column.rb
+++ b/lib/cm_admin/models/column.rb
@@ -2,7 +2,7 @@ module CmAdmin
   module Models
     class Column
       attr_accessor :field_name, :field_type, :header, :format, :prefix, :suffix, :exportable, :round,
-      :cm_css_class, :link, :url, :custom_method, :helper_method, :managable, :lockable
+      :cm_css_class, :link, :url, :custom_method, :helper_method, :managable, :lockable, :sortable, :sort_direction
 
       def initialize(field_name, attributes = {})
         @field_name = field_name

--- a/lib/cm_admin/models/controller_method.rb
+++ b/lib/cm_admin/models/controller_method.rb
@@ -7,23 +7,23 @@ module CmAdmin
         @current_action = CmAdmin::Models::Action.find_by(self, name: 'show')
         @ar_object = @ar_model.find(params[:id])
       end
-  
+
       def index(params)
         @current_action = CmAdmin::Models::Action.find_by(self, name: 'index')
         # Based on the params the filter and pagination object to be set
         @ar_object = filter_by(params, nil, filter_params(params))
       end
-  
+
       def new(params)
         @current_action = CmAdmin::Models::Action.find_by(self, name: 'new')
         @ar_object = @ar_model.new
       end
-  
+
       def edit(params)
         @current_action = CmAdmin::Models::Action.find_by(self, name: 'edit')
         @ar_object = @ar_model.find(params[:id])
       end
-  
+
       def update(params)
         @ar_object = @ar_model.find(params[:id])
         @ar_object.assign_attributes(resource_params(params))
@@ -50,7 +50,7 @@ module CmAdmin
         # filtered_result.facets.sort = sort_params
         return filtered_result
       end
-  
+
       def resource_params(params)
         permittable_fields = @permitted_fields || @ar_model.columns.map(&:name).reject { |i| CmAdmin::REJECTABLE_FIELDS.include?(i) }.map(&:to_sym)
         permittable_fields += @ar_model.reflect_on_all_attachments.map {|x|

--- a/lib/cm_admin/models/controller_method.rb
+++ b/lib/cm_admin/models/controller_method.rb
@@ -41,6 +41,12 @@ module CmAdmin
         sort_direction = %w[asc desc].include?(sort_params[:sort_direction]) ? sort_params[:sort_direction] : "asc"
         sort_params = {sort_column: sort_column, sort_direction: sort_direction}
         records = self.name.constantize.where(nil) if records.nil?
+        sortable_columns = available_fields[current_action.name.to_sym].select(&:sortable)
+        if sortable_columns.any?
+          sortable_columns.each do |column|
+            records = records.order("#{column.field_name} #{column.sort_direction}")
+          end
+        end
         final_data = CmAdmin::Models::Filter.filtered_data(filter_params, records, @filters)
         pagy, records = pagy(final_data)
         filtered_result.data = records

--- a/lib/cm_admin/models/dsl_method.rb
+++ b/lib/cm_admin/models/dsl_method.rb
@@ -87,6 +87,11 @@ module CmAdmin
       end
 
       def column(field_name, options={})
+        db_columns = self.instance_variable_get(:@ar_model)&.columns&.map{|x| x.name.to_sym}
+        if options[:sort_direction].present? && !db_columns.include?(field_name)
+          raise "Sorting for custom column #{field_name} does not exist."
+        end
+
         @available_fields[@current_action.name.to_sym] ||= []
         if @available_fields[@current_action.name.to_sym].select{|x| x.lockable}.size > 0 && options[:lockable]
           raise "Only one column can be locked in a table."

--- a/lib/cm_admin/models/dsl_method.rb
+++ b/lib/cm_admin/models/dsl_method.rb
@@ -24,14 +24,14 @@ module CmAdmin
         @current_action.page_description = page_description
         yield
       end
-  
+
       def cm_edit(page_title: nil,page_description: nil, &block)
         @current_action = CmAdmin::Models::Action.find_by(self, name: 'edit')
         @current_action.page_title = page_title
         @current_action.page_description = page_description
         yield
       end
-  
+
       def cm_new(page_title: nil,page_description: nil,&block)
         @current_action = CmAdmin::Models::Action.find_by(self, name: 'new')
         @current_action.page_title = page_title
@@ -44,13 +44,13 @@ module CmAdmin
           @current_action.page_title = title
         end
       end
-  
+
       def page_description(description)
         if @current_action
           @current_action.page_description = description
         end
       end
-  
+
       def tab(tab_name, custom_action, associated_model: nil, layout_type: nil, layout: nil, partial: nil, &block)
         if custom_action.to_s == ''
           @current_action = CmAdmin::Models::Action.find_by(self, name: 'show')
@@ -65,12 +65,12 @@ module CmAdmin
         end
         yield if block
       end
-  
+
       def cm_show_section(section_name, &block)
         @available_fields[@current_action.name.to_sym] ||= []
         @available_fields[@current_action.name.to_sym] << CmAdmin::Models::CmShowSection.new(section_name, &block)
       end
-  
+
       def form_field(field_name, options={}, arg=nil)
         unless @current_action.is_nested_field
           @available_fields[@current_action.name.to_sym][:fields] << CmAdmin::Models::FormField.new(field_name, options[:input_type], options)
@@ -79,23 +79,24 @@ module CmAdmin
           @available_fields[@current_action.name.to_sym][@current_action.nested_table_name] << CmAdmin::Models::FormField.new(field_name, options[:input_type], options)
         end
       end
-  
+
       def nested_form_field(field_name, &block)
         @current_action.is_nested_field = true
         @current_action.nested_table_name = field_name
         yield
       end
-  
+
       def column(field_name, options={})
         @available_fields[@current_action.name.to_sym] ||= []
         if @available_fields[@current_action.name.to_sym].select{|x| x.lockable}.size > 0 && options[:lockable]
           raise "Only one column can be locked in a table."
         end
+
         unless @available_fields[@current_action.name.to_sym].map{|x| x.field_name.to_sym}.include?(field_name)
           @available_fields[@current_action.name.to_sym] << CmAdmin::Models::Column.new(field_name, options)
         end
       end
-  
+
       def all_db_columns(options={})
         field_names = self.instance_variable_get(:@ar_model)&.columns&.map{|x| x.name.to_sym}
         if options.include?(:exclude) && field_names


### PR DESCRIPTION
We have introduced 2 new keys in column DSL for sorting the records,
1. `sortable` - boolean
2. `sort_direction` - string/symbol

Values that can be passed in `sort_direction` are,
- ASC, asc, :asc
- DESC, desc, :desc

If `sort_direction` is present with the valid values then we automatically mark the column as sortable. Another way of making a column sortable is by setting the value for `sortable` as true and if no sort direction is provided then the default value `asc` will be set.

Ex:
```ruby
cm_admin do
  cm_index do
    column :last_name, sortable: true, sort_direction: :desc
    column :first_name, sort_direction: :desc
    column :email, sortable: true
  end
end
```
We have added a bunch of validation,
1. Sorting would currently be applicable for DB columns and not for custom columns.
2. Use of valid values for `sort_direction`.