### PR TITLE
feat(user-permission): Basic working DSL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'slim'
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem 'cocoon'
+gem 'pundit'
 
 # Specify your gem's dependencies in cm_admin.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,40 @@
 PATH
   remote: .
   specs:
-    cm-admin (0.4.2)
+    cm-admin (0.5.7)
       axlsx_rails (~> 0.6.1)
       cocoon (~> 1.2.15)
       pagy (~> 4.11.0)
+      pundit (~> 2.2.0)
       slim (~> 4.1.0)
       webpacker (~> 5.2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (6.1.4.1)
-      actionview (= 6.1.4.1)
-      activesupport (= 6.1.4.1)
-      rack (~> 2.0, >= 2.0.9)
+    actionpack (7.0.2.3)
+      actionview (= 7.0.2.3)
+      activesupport (= 7.0.2.3)
+      rack (~> 2.0, >= 2.2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.1.4.1)
-      activesupport (= 6.1.4.1)
+    actionview (7.0.2.3)
+      activesupport (= 7.0.2.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (6.1.4.1)
+    activesupport (7.0.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     axlsx_rails (0.6.1)
       actionpack (>= 3.1)
       caxlsx (>= 3.0)
     builder (3.2.4)
-    caxlsx (3.1.1)
+    caxlsx (3.2.0)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
       nokogiri (~> 1.10, >= 1.10.4)
@@ -45,20 +45,24 @@ GEM
     diff-lcs (1.4.4)
     erubi (1.10.0)
     htmlentities (4.3.4)
-    i18n (1.8.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    loofah (2.12.0)
+    loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     marcel (1.0.2)
     method_source (1.0.0)
-    minitest (5.14.4)
-    nokogiri (1.12.5-x86_64-darwin)
+    mini_portile2 (2.8.0)
+    minitest (5.15.0)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pagy (4.11.0)
-    racc (1.5.2)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
+    racc (1.6.0)
     rack (2.2.3)
-    rack-proxy (0.7.0)
+    rack-proxy (0.7.2)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -67,12 +71,13 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    railties (6.1.4.1)
-      actionpack (= 6.1.4.1)
-      activesupport (= 6.1.4.1)
+    railties (7.0.2.3)
+      actionpack (= 7.0.2.3)
+      activesupport (= 7.0.2.3)
       method_source
-      rake (>= 0.13)
+      rake (>= 12.2)
       thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rake (12.3.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -93,7 +98,7 @@ GEM
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
     temple (0.8.2)
-    thor (1.1.0)
+    thor (1.2.1)
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -102,7 +107,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
@@ -111,9 +116,10 @@ DEPENDENCIES
   cm-admin!
   cocoon
   pagy (~> 4.11.0)
+  pundit
   rake (~> 12.0)
   rspec (~> 3.0)
   slim
 
 BUNDLED WITH
-   2.0.2
+   2.2.33

--- a/app/controllers/cm_admin/application_controller.rb
+++ b/app/controllers/cm_admin/application_controller.rb
@@ -1,11 +1,14 @@
 module CmAdmin
   class ApplicationController < ::ActionController::Base
+    include Pundit::Authorization
     # before_action :check_cm_admin
     layout 'cm_admin'
     helper CmAdmin::ViewHelpers
 
+
     def check_cm_admin
       redirect_to CmAdmin::Engine.mount_path + '/access-denied' unless defined?(::Current) && ::Current.cm_admin_user
     end
+
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/views/cm_admin/main/_tabs.html.slim
+++ b/app/views/cm_admin/main/_tabs.html.slim
@@ -1,5 +1,6 @@
 ul.nav.nav-pills
   - @model.available_tabs.each do |nav_item|
-    li.nav-item
-	    - nav_item_action_name = nav_item.custom_action.present? ? nav_item.custom_action : 'show'
-	    = link_to nav_item.nav_item_name.to_s.titleize, "/cm_admin/#{@model.name.underscore.pluralize}/#{@ar_object.id}/#{nav_item.custom_action}", class: "nav-link #{ nav_item_action_name == action_name ? 'active' : ''}"
+    - if policy([:cm_admin, @model.name.classify.constantize]).send(:"#{nav_item.custom_action}?")
+      li.nav-item
+        - nav_item_action_name = nav_item.custom_action.present? ? nav_item.custom_action : 'show'
+        = link_to nav_item.nav_item_name.to_s.titleize, "/cm_admin/#{@model.name.underscore.pluralize}/#{@ar_object.id}/#{nav_item.custom_action}", class: "nav-link #{ nav_item_action_name == action_name ? 'active' : ''}"

--- a/app/views/cm_admin/static/dashboard.html.slim
+++ b/app/views/cm_admin/static/dashboard.html.slim
@@ -1,0 +1,1 @@
+| Dashboard section

--- a/app/views/cm_admin/static/error_403.html.slim
+++ b/app/views/cm_admin/static/error_403.html.slim
@@ -1,0 +1,4 @@
+main.flex-shrink-0
+  .container
+    h1.mt-5 403
+    p.lead You do not have permission to access this page.

--- a/cm_admin.gemspec
+++ b/cm_admin.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'webpacker', '~> 5.2.1'
   spec.add_runtime_dependency 'axlsx_rails', '~> 0.6.1'
   spec.add_runtime_dependency 'cocoon', '~> 1.2.15'
+  spec.add_runtime_dependency 'pundit', '~> 2.2.0'
 end

--- a/lib/cm_admin.rb
+++ b/lib/cm_admin.rb
@@ -8,10 +8,12 @@ require 'cm_admin/utils'
 module CmAdmin
   class Error < StandardError; end
 
-  mattr_accessor :layout
+  mattr_accessor :layout, :authorized_roles
   mattr_accessor :included_models, :cm_admin_models
+  @@authorized_roles ||= []
   @@included_models ||= []
   @@cm_admin_models ||= []
+  
 
   class << self
     def webpacker
@@ -24,6 +26,7 @@ module CmAdmin
     def setup
       yield self
     end
+
 
     def config(entity, &block)
       if entity.is_a?(Class)

--- a/lib/cm_admin/model.rb
+++ b/lib/cm_admin/model.rb
@@ -14,6 +14,7 @@ require_relative 'models/controller_method'
 require 'pagy'
 require 'axlsx'
 require 'cocoon'
+require 'pundit'
 
 module CmAdmin
   class Model
@@ -44,6 +45,7 @@ module CmAdmin
       actions unless @actions_set
       $available_actions = @available_actions.dup
       self.class.all_actions.push(@available_actions)
+      define_policy
       define_controller
     end
 
@@ -99,10 +101,30 @@ module CmAdmin
 
     private
 
+    def define_policy
+      klass = Class.new(ApplicationPolicy) do
+        def initialize(user, record)
+          @user = user
+          @record = record
+        end
+
+        $available_actions.each do |action|
+          define_method :"#{action.name}?" do
+            accessible_by = action.accessible_by.map { |role| "user.#{role}" }.join(' || ')
+            eval(accessible_by)
+          end
+        end
+      end
+      CmAdmin.const_set "#{@name}Policy", klass
+    end
+
     # Controller defined for each model
     # If model is User, controller will be UsersController
     def define_controller
       klass = Class.new(CmAdmin::ApplicationController) do
+        include Pundit::Authorization
+        rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
         $available_actions.each do |action|
           define_method action.name.to_sym do
 
@@ -113,6 +135,7 @@ module CmAdmin
             @model.current_action = @action
             @ar_object = @model.try(@action.parent || action_name, params)
             @ar_object, @associated_model, @associated_ar_object = @model.custom_controller_action(action_name, params.permit!) if !@ar_object.present? && params[:id].present?
+            authorize controller_name.classify.constantize, policy_class: "CmAdmin::#{controller_name.classify}Policy".constantize
             aar_model = request.url.split('/')[-2].classify.constantize  if params[:aar_id]
             @associated_ar_object = aar_model.find(params[:aar_id]) if params[:aar_id]
             nested_tables = @model.available_fields[:new].except(:fields).keys
@@ -162,6 +185,12 @@ module CmAdmin
               end
             end
           end
+        end
+        private
+
+        def user_not_authorized
+          flash[:alert] = 'You are not authorized to perform this action.'
+          redirect_to CmAdmin::Engine.mount_path + '/access-denied'
         end
       end if $available_actions.present?
       CmAdmin.const_set "#{@name}Controller", klass

--- a/lib/cm_admin/models/action.rb
+++ b/lib/cm_admin/models/action.rb
@@ -6,7 +6,7 @@ module CmAdmin
       include Actions::Blocks
       attr_accessor :name, :verb, :layout_type, :layout, :partial, :path, :page_title, :page_description,
         :child_records, :is_nested_field, :nested_table_name, :parent, :display_if, :route_type, :code_block,
-        :display_type, :action_type, :redirection_url, :sort_direction, :sort_column
+        :display_type, :action_type, :redirection_url, :sort_direction, :sort_column, :accessible_by
 
       VALID_SORT_DIRECTION = Set[:asc, :desc].freeze
 
@@ -34,6 +34,14 @@ module CmAdmin
         self.action_type = :default
         self.sort_column = :created_at
         self.sort_direction = :desc
+        self.accessible_by = CmAdmin.authorized_roles
+      end
+
+      def set_values(page_title, page_description, partial, accessible_by)
+        self.page_title = page_title
+        self.page_description = page_description
+        self.partial = partial
+        self.accessible_by = (CmAdmin.authorized_roles.dup << accessible_by).flatten.compact.uniq if accessible_by
       end
 
       class << self

--- a/lib/cm_admin/view_helpers/navigation_helper.rb
+++ b/lib/cm_admin/view_helpers/navigation_helper.rb
@@ -7,23 +7,25 @@ module CmAdmin
         CmAdmin.cm_admin_models.map { |model|
           if model.is_visible_on_sidebar
             path = CmAdmin::Engine.mount_path + '/' + model.name.underscore.pluralize
-            if navigation_type == "sidebar"
-              content_tag(:a, href: path) do
-                content_tag(:div, class: 'menu-item') do
-                  content_tag(:span, class: 'menu-icon') do
-                    concat tag.i class: "#{model.icon_name}"
-                  end +
-                  model.name.pluralize
+            if policy([:cm_admin, model.name.classify.constantize]).index?
+              if navigation_type == "sidebar"
+                content_tag(:a, href: path) do
+                  content_tag(:div, class: 'menu-item') do
+                    content_tag(:span, class: 'menu-icon') do
+                      concat tag.i class: "#{model.icon_name}"
+                    end +
+                    model.name.pluralize
+                  end
                 end
-              end
-            elsif navigation_type == "quick_links"
-              content_tag(:a, href: path, class: 'visible') do
-                content_tag(:div, class: 'result-item') do
-                  content_tag(:span) do
-                    concat tag.i class: "#{model.icon_name}"
-                  end +
-                  content_tag(:span) do
-                    model.name
+              elsif navigation_type == "quick_links"
+                content_tag(:a, href: path, class: 'visible') do
+                  content_tag(:div, class: 'result-item') do
+                    content_tag(:span) do
+                      concat tag.i class: "#{model.icon_name}"
+                    end +
+                    content_tag(:span) do
+                      model.name
+                    end
                   end
                 end
               end


### PR DESCRIPTION
- Pundit dependency added
- `accessible_by` needs to be added to cm_index, custom_action keywords
- Inside cm_admin initializer set the default role `config.authorized_roles`
- error 403 added for permission denied.

Sample DSL

```
cm_index accessible_by: [:admin?, :senior_coach?] do
  ...
end
```
Note:
- accessible_by gets added to the default authorized roles, it does not replace it.