### PR TITLE
fix: Show initialized record once

### DIFF
--- a/app/views/cm_admin/main/_nested_table_form.html.slim
+++ b/app/views/cm_admin/main/_nested_table_form.html.slim
@@ -1,7 +1,10 @@
 .nested-field-wrapper
   label.field-label = table_name.to_s.titleize
+  - initialized_record_count = 1
   = f.fields_for table_name do |record|
-    = render partial: '/cm_admin/main/nested_fields', locals: { f: record, assoc_name: table_name }
+    - if record.object.persisted? || initialized_record_count == 1
+      = render partial: '/cm_admin/main/nested_fields', locals: { f: record, assoc_name: table_name }
+    - initialized_record_count += 1 if record.object.new_record?
   - if @reflections.select {|x| x if x.name == table_name}.first.macro == :has_many
     .links
       = link_to_add_association "+ Add #{table_name.to_s.titleize}", f, table_name, partial: '/cm_admin/main/nested_fields', render_options:  {locals: { assoc_name: table_name }}


### PR DESCRIPTION
**Patch work:**

- Initialized records are shown multiple times in the new and the edit pages.
- Wrote an if condition to show it only once. 
- Ideally it should be working without this if condition