### PR TITLE
Improvement for URL generation for the custom action in the table

### DIFF
--- a/app/views/cm_admin/main/_associated_table.html.slim
+++ b/app/views/cm_admin/main/_associated_table.html.slim
@@ -46,7 +46,10 @@
                     - if custom_action.display_if.call(ar_object)
                       .popup-option
                         - if custom_action.display_type == :button
-                          = link_to custom_action.name.titleize, custom_action.path.gsub(':id', ar_object.id.to_s), method: custom_action.verb
+                          = link_to cm_admin.send("#{@associated_model.name.underscore}_index_path") + '/' + custom_action.path.gsub(':id', ar_object.id.to_s), method: custom_action.verb do
+                            span
+                              i class="#{custom_action.icon_name}"
+                            = custom_action.name.humanize
                         - elsif custom_action.display_type == :modal
                           = link_to custom_action.name.titleize, '', data: { bs_toggle: 'modal', bs_target: "##{custom_action.name.classify}Modal-#{ar_object.id.to_s}" }
 

--- a/app/views/cm_admin/main/_associated_table.html.slim
+++ b/app/views/cm_admin/main/_associated_table.html.slim
@@ -51,7 +51,7 @@
                               i class="#{custom_action.icon_name}"
                             = custom_action.name.humanize
                         - elsif custom_action.display_type == :modal
-                          = link_to custom_action.name.titleize, '', data: { bs_toggle: 'modal', bs_target: "##{custom_action.name.classify}Modal-#{ar_object.id.to_s}" }
+                          = link_to custom_action.name.humanize, '', data: { bs_toggle: 'modal', bs_target: "##{custom_action.name.classify}Modal-#{ar_object.id.to_s}" }
 
 .cm-pagination
   .cm-pagination__lhs Showing #{@associated_ar_object.pagy.from} to #{@associated_ar_object.pagy.to} out of #{@associated_ar_object.pagy.count}

--- a/app/views/cm_admin/main/_associated_table.html.slim
+++ b/app/views/cm_admin/main/_associated_table.html.slim
@@ -48,8 +48,8 @@
                         - if custom_action.display_type == :button
                           = link_to custom_action.name.titleize, custom_action.path.gsub(':id', ar_object.id.to_s), method: custom_action.verb
                         - elsif custom_action.display_type == :modal
-                          = link_to custom_action.name.titleize, '', data: { bs_toggle: "modal", bs_target: "##{custom_action.name.classify}Modal-#{ar_object.id.to_s}" }
-                
+                          = link_to custom_action.name.titleize, '', data: { bs_toggle: 'modal', bs_target: "##{custom_action.name.classify}Modal-#{ar_object.id.to_s}" }
+
 .cm-pagination
   .cm-pagination__lhs Showing #{@associated_ar_object.pagy.from} to #{@associated_ar_object.pagy.to} out of #{@associated_ar_object.pagy.count}
   .cm-pagination__rhs
@@ -57,11 +57,11 @@
 
 - @associated_ar_object.data.each do |ar_object|
   - @associated_model && @associated_model.available_actions.select{|act| act if (act.route_type == 'member' && act.display_type == :modal)}.each do |custom_action|
-    .modal.fade id="#{custom_action.name.classify}Modal-#{ar_object.id.to_s}" aria-hidden="true" aria-labelledby="#{custom_action.name.classify}ModalLabel" tabindex="1" 
+    .modal.fade id="#{custom_action.name.classify}Modal-#{ar_object.id.to_s}" aria-hidden='true' aria-labelledby="#{custom_action.name.classify}ModalLabel" tabindex='1'
       .modal-dialog
         .modal-content
           .modal-header
             h5.modal-title id="#{custom_action.name.classify}ModalLabel" = custom_action.name.classify
-            button.btn-close aria-label="Close" data-bs-dismiss="modal" type="button" 
+            button.btn-close aria-label='Close' data-bs-dismiss='modal'
           .modal-body
             = render partial: custom_action.partial, locals: { ar_object: ar_object }

--- a/app/views/cm_admin/main/_associated_table.html.slim
+++ b/app/views/cm_admin/main/_associated_table.html.slim
@@ -2,11 +2,11 @@
   .table-top
     p.table-top__total-count = "#{@associated_ar_object.pagy.count} #{@action.child_records.to_s.gsub('_', ' ')} found"
     .table-top__column-action
-      button.secondary-btn.column-btn data-target="#columnActionModal" data-toggle="modal" type="button"
-        span
-          i.fa.fa-columns.bolder
-        span
-          i.fa.fa-angle-down
+      / button.secondary-btn.column-btn data-target="#columnActionModal" data-toggle="modal" type="button"
+      /   span
+      /     i.fa.fa-columns.bolder
+      /   span
+      /     i.fa.fa-angle-down
 
 .new-admin-table.scrollable
   table.cm-table

--- a/app/views/cm_admin/main/_table.html.slim
+++ b/app/views/cm_admin/main/_table.html.slim
@@ -53,7 +53,7 @@
                   - custom_actions.each do |custom_action|
                     - if custom_action.name.present? && has_valid_policy(@model.name, custom_action.name)
                       - if custom_action.display_if.call(ar_object)
-                        = link_to cm_admin.send("#{@model.name.downcase}_index_path") + '/' + custom_action.path.gsub(':id', ar_object.id.to_s), method: custom_action.verb do
+                        = link_to cm_admin.send("#{@model.name.underscore}_index_path") + '/' + custom_action.path.gsub(':id', ar_object.id.to_s), method: custom_action.verb do
                           .popup-option
                             span
                               i class="#{custom_action.icon_name}"

--- a/app/views/cm_admin/main/_table.html.slim
+++ b/app/views/cm_admin/main/_table.html.slim
@@ -57,7 +57,7 @@
                           .popup-option
                             span
                               i class="#{custom_action.icon_name}"
-                            = custom_action.name.titleize
+                            = custom_action.name.humanize
 
 .cm-pagination
   .cm-pagination__lhs Showing #{@ar_object.pagy.from} to #{@ar_object.pagy.to} out of #{@ar_object.pagy.count}


### PR DESCRIPTION
## JIRA Ticket
[CMAD-96](https://commutatus.atlassian.net/browse/CMAD-96)

## What?
1. Generate the custom action path in an associated table with the index path.
2. Added the ability to display the icon along with the custom action name in an associated table.
3. Fix the custom action path generation on the index table.
4. Humanize the names for the custom action.

## Why?
1. It is generating the relative route with the model it is being added to in view. But the rails route are not matching with it.
2. The ability to add the icon in a custom action for nested pages was missing.
3. For better readability changed `titleize` to `humanize`

## Anything Else?
This PR would be required for Unschool -> https://github.com/commutatus/unschool-api/pull/311
