### PR TITLE
Truncating the table column data for drawer element

### DIFF
--- a/app/assets/stylesheets/cm_admin/base/common.scss
+++ b/app/assets/stylesheets/cm_admin/base/common.scss
@@ -199,9 +199,10 @@
   margin-left: 2px;
 }
 
-.text-ellipsis div {
-  overflow: hidden;
+.text-ellipsis {
   text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 @keyframes shakeError {

--- a/lib/cm_admin/view_helpers/field_display_helper.rb
+++ b/lib/cm_admin/view_helpers/field_display_helper.rb
@@ -58,9 +58,9 @@ module CmAdmin
           when :attachment
             concat show_attachment_value(ar_object, field)
           when :drawer
-            content_tag :span do
-              concat content_tag(:span, truncate(ar_object.send(field.field_name).to_s, length: 25))
-              concat content_tag(:span, 'View', class: 'drawer-btn')
+            content_tag :div, class: 'd-flex' do
+              concat content_tag(:div, ar_object.send(field.field_name).to_s, class: 'text-ellipsis')
+              concat content_tag(:div, 'View', class: 'drawer-btn')
             end
           end
         end

--- a/lib/cm_admin/view_helpers/field_display_helper.rb
+++ b/lib/cm_admin/view_helpers/field_display_helper.rb
@@ -25,43 +25,41 @@ module CmAdmin
       end
 
       def show_field_value(ar_object, field)
-        content_tag(:span) do
-          case field.field_type || :string
-          when :integer
+        case field.field_type || :string
+        when :integer
+          ar_object.send(field.field_name).to_s
+        when :decimal
+          ar_object.send(field.field_name).to_f.round(field.precision).to_s if ar_object.send(field.field_name)
+        when :string
+          ar_object.send(field.field_name).to_s
+        when :datetime
+          ar_object.send(field.field_name).strftime(field.format || "%d/%m/%Y").to_s if ar_object.send(field.field_name)
+        when :text
+          ar_object.send(field.field_name)
+        when :custom
+          send(field.helper_method, ar_object, field.field_name)
+        when :link
+          if field.custom_link
+            link = field.custom_link
+          else
+            link = ar_object.send(field.field_name)
+          end
+          content_tag :a, href: link do
             ar_object.send(field.field_name).to_s
-          when :decimal
-            ar_object.send(field.field_name).to_f.round(field.precision).to_s if ar_object.send(field.field_name)
-          when :string
-            ar_object.send(field.field_name).to_s
-          when :datetime
-            ar_object.send(field.field_name).strftime(field.format || "%d/%m/%Y").to_s if ar_object.send(field.field_name)
-          when :text
-            ar_object.send(field.field_name)
-          when :custom
-            send(field.helper_method, ar_object, field.field_name)
-          when :link
-            if field.custom_link
-              link = field.custom_link
-            else
-              link = ar_object.send(field.field_name)
-            end
-            content_tag :a, href: link do
-              ar_object.send(field.field_name).to_s
-            end
-          when :enum
-            ar_object.send(field.field_name).to_s.titleize
-          when :tag
-            tag_class = field.tag_class.dig("#{ar_object.send(field.field_name.to_s)}".to_sym).to_s
-            content_tag :span, class: "status-tag #{tag_class}" do
-              ar_object.send(field.field_name).to_s.upcase
-            end
-          when :attachment
-            concat show_attachment_value(ar_object, field)
-          when :drawer
-            content_tag :div, class: 'd-flex' do
-              concat content_tag(:div, ar_object.send(field.field_name).to_s, class: 'text-ellipsis')
-              concat content_tag(:div, 'View', class: 'drawer-btn')
-            end
+          end
+        when :enum
+          ar_object.send(field.field_name).to_s.titleize
+        when :tag
+          tag_class = field.tag_class.dig("#{ar_object.send(field.field_name.to_s)}".to_sym).to_s
+          content_tag :span, class: "status-tag #{tag_class}" do
+            ar_object.send(field.field_name).to_s.upcase
+          end
+        when :attachment
+          concat show_attachment_value(ar_object, field)
+        when :drawer
+          content_tag :div, class: 'd-flex' do
+            concat content_tag(:div, ar_object.send(field.field_name).to_s, class: 'text-ellipsis')
+            concat content_tag(:div, 'View', class: 'drawer-btn')
           end
         end
       end


### PR DESCRIPTION
## JIRA Ticket
[CMAD-95](https://commutatus.atlassian.net/browse/CMAD-95)

## What?
1. Improvement for truncating the content with the drawer element
2. Include the `text-ellipsis` class.

## Why?
1. The `View` button is also getting truncated if the text is long.
<img width="1397" alt="image-20220510-092500" src="https://user-images.githubusercontent.com/20839528/168218953-4198d008-7be2-4434-982b-93020b9b79d1.png">
2. Since the `text-ellipsis` class was for div element it is not getting applied globally.
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/20839528/168219073-ba4a6090-c8ea-4395-8d07-03dfa8876209.png">

