### PR TITLE
Added gsub to remove _attachment from params

### DIFF
--- a/lib/cm_admin/models/controller_method.rb
+++ b/lib/cm_admin/models/controller_method.rb
@@ -68,9 +68,9 @@ module CmAdmin
             x.name
           elsif x.klass.name == "ActiveStorage::Attachment"
             if x.class.name.include?('HasOne')
-              x.name
+              x.name.to_s.gsub('_attachment', '').to_sym
             elsif x.class.name.include?('HasMany')
-              Hash[x.name.to_s, []]
+              Hash[x.name.to_s.gsub('_attachment', ''), []]
             end
           elsif x.klass.name == "ActionText::RichText"
             x.name.to_s.gsub('rich_text_', '').to_sym


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->

## JIRA Ticket
<!-- Replace the ticket number here. Make sure to update both the name and the link -->
[MYCN-983](https://commutatus.atlassian.net/browse/MYCN-983)


## What?
<!-- Explain the changes you’ve made. It doesn’t need to be fancy
and you don’t have to get too technical, yet. Just explicit prose
on your net change will typically suffice. -->
Fix for File upload not working.


## Why?
<!-- Explain both the engineering goal and also some business
objective that is satisfied or moved along -->
While single file upload, we were getting error of Unpermitted params.


## How?
<!-- Use this section to draw attention to the significant design decisions
you made -->
Upon Inspection, we found out rails was automatically attaching _attachment, at the end of the params. So for example, the original params was profile_picture then it would become  profile_picture_attachment in cm-admin. We removed the last part using gsub.


## Testing?
<!-- Let the reviewer know how you tested the changes. Showing the
results of tests you’ve run is also very helpful. Let the reviewer
also know if some conditions or edge cases were not tested -->
Done in Climber project.
Working in Rails 6.1.5
