### PR TITLE
fix: PRO-3914 - remove underscore in tags

### DIFF
--- a/lib/cm_admin/view_helpers/field_display_helper.rb
+++ b/lib/cm_admin/view_helpers/field_display_helper.rb
@@ -71,7 +71,7 @@ module CmAdmin
         when :tag
           tag_class = field.tag_class.dig("#{ar_object.send(field.field_name.to_s)}".to_sym).to_s
           content_tag :span, class: "status-tag #{tag_class}" do
-            ar_object.send(field.field_name).to_s.upcase.split('_').join(' ')
+            ar_object.send(field.field_name).to_s.titleize.upcase
           end
         when :attachment
           show_attachment_value(ar_object, field)

--- a/lib/cm_admin/view_helpers/field_display_helper.rb
+++ b/lib/cm_admin/view_helpers/field_display_helper.rb
@@ -71,7 +71,7 @@ module CmAdmin
         when :tag
           tag_class = field.tag_class.dig("#{ar_object.send(field.field_name.to_s)}".to_sym).to_s
           content_tag :span, class: "status-tag #{tag_class}" do
-            ar_object.send(field.field_name).to_s.upcase
+            ar_object.send(field.field_name).to_s.upcase.split('_').join(' ')
           end
         when :attachment
           show_attachment_value(ar_object, field)


### PR DESCRIPTION
Tags used to have underscore in them (THIS_IS_A_TAG). I've removed the underscore (THIS IS A TAG)


## Before
<img width="730" alt="Screenshot 2024-06-14 at 12 19 36 PM" src="https://github.com/commutatus/cm-admin/assets/40666000/f536136a-638f-48b1-a297-ae186ca9f5c2">


<img width="701" alt="Screenshot 2024-06-14 at 12 30 14 PM" src="https://github.com/commutatus/cm-admin/assets/40666000/e9997d2f-5ad4-4a9d-baea-317d38a48d46">


## After
<img width="730" alt="Screenshot 2024-06-14 at 12 29 12 PM" src="https://github.com/commutatus/cm-admin/assets/40666000/6dd2bb5a-a318-4005-8f7a-3e2b308ed86e">


<img width="701" alt="Screenshot 2024-06-14 at 12 29 37 PM" src="https://github.com/commutatus/cm-admin/assets/40666000/dc858cba-4557-4012-9a86-502bfc772bc3">

