### PR TITLE
ci: remove reek

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,10 +19,6 @@ jobs:
           rubocop_extensions: rubocop-rails:2.14.2
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check # Possible values are github-pr-check, github-pr-review
-      - name: reek
-        uses: reviewdog/action-reek@v1
-        with:
-          reek_version: 6.1.1
       - uses: actions/checkout@v3
       - name: stylelint
         uses: reviewdog/action-stylelint@v1

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,9 +1,0 @@
-detectors:
-  IrresponsibleModule:
-    enabled: false
-  UncommunicativeVariableName:
-    enabled: true
-    accept:
-      - e
-  TooManyStatements:
-    enabled: false


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What does this change do?
This PR removes reek and also the Github Action associated with Reek



## Why is this change needed?
1. Rubocop and Reek are doing the same thing in certain cases.
2. While Reek focuses on code smells, we are not able to use a common file for Reek in all our projects; this makes it hard to keep the file updated from a parent repository on Github.
3. I feel we should first focus on getting a good rubocop implementation and then later we can move on to reek.

