### PR TITLE
fix: remove div for display_if false in form field

### DIFF
--- a/lib/cm_admin/view_helpers/form_helper.rb
+++ b/lib/cm_admin/view_helpers/form_helper.rb
@@ -101,9 +101,9 @@ module CmAdmin
       end
 
       def set_form_field(resource, form_obj, field)
-        content_tag(:div, class: field.col_size ? "col-#{field.col_size}" : 'col') do
-          next unless field.display_if.call(form_obj.object)
+        return unless field.display_if.call(form_obj.object)
 
+        content_tag(:div, class: field.col_size ? "col-#{field.col_size}" : 'col') do
           if field.input_type.eql?(:hidden)
             concat input_field_for_column(form_obj, field)
           else


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What does this change do?
- remove div for display_if false in the form field



## Why is this change needed?
- if display_if is false in form field column view some empty space was still left.



## How were the changes done?
- change method for `set_form_field` to return if display_if is false.


https://github.com/commutatus/cm-admin/assets/68422113/6b620751-9907-4a51-aa0d-193fcf3b221a


