### PR TITLE
fix: Multiselect typo issue fixed

### DIFF
--- a/cm_admin.gemspec
+++ b/cm_admin.gemspec
@@ -3,8 +3,8 @@ require_relative 'lib/cm_admin/version'
 Gem::Specification.new do |spec|
   spec.name          = 'cm-admin'
   spec.version       = CmAdmin::VERSION
-  spec.authors       = %w[sajinmp anbublacky AdityaTiwari2102]
-  spec.email         = ['sajinprasadkm@gmail.com', 'anbublacky@gmail.com', 'taditya.tiwari007@gmail.com']
+  spec.authors       = ['Michael', 'Anbazhagan', 'Ayza', 'Barath', 'Pranav', 'Mahaveer']
+  spec.email         = ['mkv@commutatus.com', 'anbublacky@gmail.com', 'ayza@commutatus.com', 'barath@commutatus.com', 'pranav@commutatus.com', 'mahaveer@commutatus.com']
 
   spec.summary       = 'CmAdmin is a robust gem designed to assist in creating admin panels for Rails applications'
   spec.description   = 'CmAdmin providing a streamlined and efficient solution for building customized admin panels within the context of Rails applications. Its robust features empower developers to effortlessly generate and manage administrative interfaces with precision and ease.'

--- a/lib/cm_admin/view_helpers/field_display_helper.rb
+++ b/lib/cm_admin/view_helpers/field_display_helper.rb
@@ -118,7 +118,9 @@ module CmAdmin
             field_name = find_field_name(field, association_name)
             link_to ar_object.send(field.association_name).send(field_name), cm_admin.send("#{association_name}_show_path", ar_object.send(field.association_name))
           elsif ['belongs_to', 'has_one'].include? field.association_type.to_s
-            link_to ar_object.send(field.association_name).send(field.field_name), cm_admin.send("#{field.association_name}_show_path", ar_object.send(field.association_name))
+            if ar_object.send(field.association_name)
+              link_to ar_object.send(field.association_name).send(field.field_name), cm_admin.send("#{field.association_name}_show_path", ar_object.send(field.association_name))
+            end
           end
         end
       end

--- a/lib/cm_admin/view_helpers/form_field_helper.rb
+++ b/lib/cm_admin/view_helpers/form_field_helper.rb
@@ -83,7 +83,7 @@ module CmAdmin
       def cm_custom_single_select_field(form_obj, cm_field, value, required_class, target_action, _ajax_url)
         select_tag cm_field.html_attrs[:name] || cm_field.field_name,
                     options_for_select(select_collection_value(form_obj.object, cm_field)),
-                    {include_blank: cm_field.placeholder}
+                    { include_blank: cm_field.placeholder },
                     merge_wrapper_options(
                     {
                       class: "field-control #{required_class} select-2",
@@ -100,7 +100,7 @@ module CmAdmin
       def cm_multi_select_field(form_obj, cm_field, value, required_class, target_action, _ajax_url)
         form_obj.select cm_field.field_name,
                         options_for_select(select_collection_value(form_obj.object, cm_field), form_obj.object.send(cm_field.field_name)),
-                        {include_blank: cm_field.placeholder}
+                        { include_blank: cm_field.placeholder },
                         merge_wrapper_options(
                         {
                           class: "field-control #{required_class} select-2",


### PR DESCRIPTION
## What does this change do?
- Multi select was not working earlier, since there was a syntax issue.  It is fixed now


## Why is this change needed?
- Multi select was not working



## How were the changes done?
- Made changes on the form field helper file, fixed the syntax issue


## Screenshots/Recording (optional)
<img width="1421" alt="image" src="https://github.com/commutatus/cm-admin/assets/798103/792d07b5-a8af-4c64-9c74-6c62f49aa20f">
