### PR TITLE
update: show tab name instead table name in associated tab

### DIFF
--- a/app/views/cm_admin/main/_associated_table.html.slim
+++ b/app/views/cm_admin/main/_associated_table.html.slim
@@ -2,7 +2,7 @@
   - if @associated_model.filters.present? && @action.partial.nil?
     .cm-index-page__filters
       == render partial: 'cm_admin/main/filters', locals: { filters: @associated_model.filters }
-  p.table-top__total-count = "#{humanized_ar_collection_count(@associated_ar_object.pagy.count, @action.child_records.to_s)}"
+  p.table-top__total-count = "#{humanized_ar_collection_count(@associated_ar_object.pagy.count, (@action.tab_name.present? ? @action.tab_name.to_s : @action.child_records.to_s))}"
   .table-top__column-action
     -
     - if @associated_model && @associated_model.available_actions.map(&:name).include?('new') && has_valid_policy(@associated_ar_object, 'new')

--- a/app/views/cm_admin/main/_associated_table.html.slim
+++ b/app/views/cm_admin/main/_associated_table.html.slim
@@ -2,7 +2,7 @@
   - if @associated_model.filters.present? && @action.partial.nil?
     .cm-index-page__filters
       == render partial: 'cm_admin/main/filters', locals: { filters: @associated_model.filters }
-  p.table-top__total-count = "#{humanized_ar_collection_count(@associated_ar_object.pagy.count, (@action.tab_name.present? ? @action.tab_name.to_s : @action.child_records.to_s))}"
+  p.table-top__total-count = "#{humanized_ar_collection_count(@associated_ar_object.pagy.count, (@action.display_name.present? ? @action.display_name.to_s : @action.child_records.to_s))}"
   .table-top__column-action
     -
     - if @associated_model && @associated_model.available_actions.map(&:name).include?('new') && has_valid_policy(@associated_ar_object, 'new')

--- a/lib/cm_admin/models/action.rb
+++ b/lib/cm_admin/models/action.rb
@@ -7,7 +7,7 @@ module CmAdmin
       attr_accessor :name, :display_name, :verb, :layout_type, :layout, :partial, :path, :page_title, :page_description,
                     :child_records, :is_nested_field, :nested_table_name, :parent, :display_if, :route_type, :code_block,
                     :display_type, :action_type, :redirection_url, :sort_direction, :sort_column, :icon_name, :scopes, :view_type,
-                    :kanban_attr, :model_name, :redirect_to, :tab_name
+                    :kanban_attr, :model_name, :redirect_to
 
       VALID_SORT_DIRECTION = Set[:asc, :desc].freeze
 
@@ -40,7 +40,6 @@ module CmAdmin
         self.verb = :get
         self.route_type = nil
         self.display_type = nil
-        self.tab_name = nil
         self.view_type = :table
         self.kanban_attr = {}
       end

--- a/lib/cm_admin/models/action.rb
+++ b/lib/cm_admin/models/action.rb
@@ -5,9 +5,9 @@ module CmAdmin
     class Action
       include Actions::Blocks
       attr_accessor :name, :display_name, :verb, :layout_type, :layout, :partial, :path, :page_title, :page_description,
-        :child_records, :is_nested_field, :nested_table_name, :parent, :display_if, :route_type, :code_block,
-        :display_type, :action_type, :redirection_url, :sort_direction, :sort_column, :icon_name, :scopes, :view_type,
-        :kanban_attr, :model_name, :redirect_to
+                    :child_records, :is_nested_field, :nested_table_name, :parent, :display_if, :route_type, :code_block,
+                    :display_type, :action_type, :redirection_url, :sort_direction, :sort_column, :icon_name, :scopes, :view_type,
+                    :kanban_attr, :model_name, :redirect_to, :tab_name
 
       VALID_SORT_DIRECTION = Set[:asc, :desc].freeze
 
@@ -40,6 +40,7 @@ module CmAdmin
         self.verb = :get
         self.route_type = nil
         self.display_type = nil
+        self.tab_name = nil
         self.view_type = :table
         self.kanban_attr = {}
       end

--- a/lib/cm_admin/models/dsl_method.rb
+++ b/lib/cm_admin/models/dsl_method.rb
@@ -61,7 +61,7 @@ module CmAdmin
         else
           action = CmAdmin::Models::Action.new(name: custom_action.to_s, verb: :get, path: ':id/'+custom_action,
                       layout_type: layout_type, layout: layout, partial: partial, child_records: associated_model,
-                      action_type: :custom, display_type: :page, model_name: self.name, tab_name: tab_name)
+                      action_type: :custom, display_type: :page, model_name: self.name, display_name: tab_name)
           @available_actions << action
           @current_action = action
           @available_tabs << CmAdmin::Models::Tab.new(tab_name, custom_action, display_if, &block)

--- a/lib/cm_admin/models/dsl_method.rb
+++ b/lib/cm_admin/models/dsl_method.rb
@@ -61,7 +61,7 @@ module CmAdmin
         else
           action = CmAdmin::Models::Action.new(name: custom_action.to_s, verb: :get, path: ':id/'+custom_action,
                       layout_type: layout_type, layout: layout, partial: partial, child_records: associated_model,
-                      action_type: :custom, display_type: :page, model_name: self.name)
+                      action_type: :custom, display_type: :page, model_name: self.name, tab_name: tab_name)
           @available_actions << action
           @current_action = action
           @available_tabs << CmAdmin::Models::Tab.new(tab_name, custom_action, display_if, &block)

--- a/lib/cm_admin/view_helpers.rb
+++ b/lib/cm_admin/view_helpers.rb
@@ -76,7 +76,7 @@ module CmAdmin
 
     def humanized_ar_collection_count(count, model_name)
       table_name = count == 1 ? model_name.singularize : model_name.pluralize
-      return "#{count} #{table_name.humanize.downcase} found"
+      "#{count} #{table_name.humanize.downcase} found"
     end
   end
 end


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What does this change do?
- show tab name instead of table name in associated tab pagination.



## How were the changes done?
- add a field `tab_name` on the action.
- if `tab_name` present then show tab name else show table_name



https://github.com/commutatus/cm-admin/assets/68422113/a56c6b67-7e91-45c0-af73-3380467849a7

