### PR TITLE
update: add helper text on fields

### DIFF
--- a/app/views/cm_admin/main/_nested_fields.html.slim
+++ b/app/views/cm_admin/main/_nested_fields.html.slim
@@ -6,6 +6,8 @@
     - nested_table_field.fields.each do |field|
       td data-field-type="#{field.input_type}"
         = input_field_for_column(f, field)
+        - if field.helper_text.present?
+          small.form-text.text-muted = field.helper_text
 - else
   .form-card.nested-fields
     .card-body
@@ -23,6 +25,8 @@
                 label.field-label = field.field_name.to_s.titleize 
               .field-input-wrapper
                 = input_field_for_column(f, field)
+                - if field.helper_text.present?
+                  small.form-text.text-muted = field.helper_text
       - if nested_table_field.associated_fields.present?
         - nested_table_field.associated_fields.each do |associated_nested_field|
           = render partial: '/cm_admin/main/nested_table_form', locals: { f: f, nested_table_field: associated_nested_field }

--- a/app/views/cm_admin/main/_nested_fields.html.slim
+++ b/app/views/cm_admin/main/_nested_fields.html.slim
@@ -6,8 +6,6 @@
     - nested_table_field.fields.each do |field|
       td data-field-type="#{field.input_type}"
         = input_field_for_column(f, field)
-        - if field.helper_text.present?
-          small.form-text.text-muted = field.helper_text
 - else
   .form-card.nested-fields
     .card-body
@@ -25,8 +23,6 @@
                 label.field-label = field.field_name.to_s.titleize 
               .field-input-wrapper
                 = input_field_for_column(f, field)
-                - if field.helper_text.present?
-                  small.form-text.text-muted = field.helper_text
       - if nested_table_field.associated_fields.present?
         - nested_table_field.associated_fields.each do |associated_nested_field|
           = render partial: '/cm_admin/main/nested_table_form', locals: { f: f, nested_table_field: associated_nested_field }

--- a/lib/cm_admin/models/form_field.rb
+++ b/lib/cm_admin/models/form_field.rb
@@ -6,7 +6,7 @@ module CmAdmin
       include Utils::Helpers
 
       attr_accessor :field_name, :label, :header, :input_type, :collection, :disabled, :helper_method,
-                    :placeholder, :display_if, :html_attrs, :target, :col_size, :ajax_url
+                    :placeholder, :display_if, :html_attrs, :target, :col_size, :ajax_url, :helper_text
 
       VALID_INPUT_TYPES = %i[
         integer decimal string single_select multi_select date date_time text

--- a/lib/cm_admin/view_helpers/form_helper.rb
+++ b/lib/cm_admin/view_helpers/form_helper.rb
@@ -111,6 +111,7 @@ module CmAdmin
               concat form_obj.label field.label, field.label, class: 'field-label'
               concat tag.br
               concat input_field_for_column(form_obj, field)
+              concat tag.small field.helper_text, class: 'form-text text-muted' if field.helper_text.present?
               concat tag.p resource.errors[field.field_name].first if resource.errors[field.field_name].present?
             end)
           end


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What does this change do?
- add helper text on form fields



## Why is this change needed?
- currently, there's no way to add helper text on the form field.



## How were the changes done?
- add new `helper_text` field on `form_field`.
- append `helper_text` on form fields if present including nested fields.


https://github.com/commutatus/cm-admin/assets/68422113/1257e5ce-8b84-4755-bbae-c4bf1f355679

