### PR TITLE
added default color to tag

### DIFF
--- a/lib/cm_admin/view_helpers/field_display_helper.rb
+++ b/lib/cm_admin/view_helpers/field_display_helper.rb
@@ -87,6 +87,7 @@ module CmAdmin
           ar_object.send(field.field_name).to_s.titleize
         when :tag
           tag_class = field.tag_class.dig("#{ar_object.send(field.field_name.to_s)}".to_sym).to_s
+          tag_class = 'neutral' if tag_class.blank?
           content_tag :span, class: "status-tag #{tag_class}" do
             ar_object.send(field.field_name).to_s.titleize.upcase
           end


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What does this change do?
By default added `neutral` colour to tag field

